### PR TITLE
simplify comparison by using the logical negation operator

### DIFF
--- a/munge.go
+++ b/munge.go
@@ -87,7 +87,7 @@ func removeDuplication(arr []string) []string {
 	map_var := map[string]bool{}
 	result := []string{}
 	for e := range arr {
-		if map_var[arr[e]] != true {
+		if !map_var[arr[e]] {
 			map_var[arr[e]] = true
 			result = append(result, arr[e])
 		}


### PR DESCRIPTION
Hello **AAVision**

This pull request aims to simplify the comparison within the **removeDuplication** function to address a warning raised by Go tools. The original code included a comparison to a **bool** constant **(map_var[arr[e]] != true)**, which can be simplified to **!map_var[arr[e]]**. This change eliminates the warning (S1002: should omit comparison to **bool** constant) and improves code readability by using the logical negation operator. The functionality and behavior of the function remain unchanged.