### PR TITLE
Deprecated strings dot title

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,5 @@ require (
 	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.1.0 // indirect
+	golang.org/x/text v0.11.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -32,5 +32,7 @@ golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.1.0 h1:g6Z6vPFA9dYBAF7DWcH6sCcOntplXsDKcliusYijMlw=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/text v0.11.0 h1:LAntKIrcmeSKERyiOh0XMV39LXS8IE9UL2yP7+f5ij4=
+golang.org/x/text v0.11.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/munge.go
+++ b/munge.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/gookit/color"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 var tmpWordList []string
@@ -100,13 +102,14 @@ func removeDuplication(arr []string) []string {
 }
 
 func munge(wrd string, level int) {
+	caser := cases.Title(language.English)
 	if level > 0 {
 		tmpWordList = append(tmpWordList, wrd)
 		tmpWordList = append(tmpWordList, strings.ToUpper(wrd))
-		tmpWordList = append(tmpWordList, strings.Title(wrd))
+		tmpWordList = append(tmpWordList, caser.String(wrd))
 	}
 	if level > 2 {
-		temp := strings.Title(wrd)
+		temp := caser.String(wrd)
 		tmpWordList = append(tmpWordList, strings.ToLower(temp))
 	}
 	if level > 4 {


### PR DESCRIPTION
Hello **AAVision**

This pull request addresses the deprecation of **strings.Title** in **Go 1.18** by replacing its usage with **caser.String** from the **golang.org/x/text/caser** package. The **strings.Title** function is no longer recommended, and utilizing **caser.String** provides a more robust and future-proof solution for title-casing strings. This update ensures compatibility with the latest Go version and enhances the codebase's maintainability by adopting the recommended approach for title-casing.

For more information about the deprecation of strings.Title in Go 1.18 and alternative solutions, please refer to the following Stack Overflow question: [Go 1.18: strings.Title is deprecated, what to use now and how?](https://stackoverflow.com/questions/71620717/in-go-1-18-strings-title-is-deprecated-what-to-use-now-and-how)